### PR TITLE
[MediaPlayer] State

### DIFF
--- a/src/components/MediaPlayer/components/Player.tsx
+++ b/src/components/MediaPlayer/components/Player.tsx
@@ -1,0 +1,124 @@
+import { ChangeEvent, MouseEvent } from "react"
+import useMediaPlayer from "../hooks/useMediaPlayer"
+import ReactPlayer from "react-player"
+
+const Player = ({ isPending = true }: { isPending?: boolean }) => {
+  const {
+    playUrl,
+    playerRef,
+    isMute,
+    isPlaying,
+    playRange,
+    volume,
+    onChangeRange,
+    onClickPlayer,
+    onChangeUrl,
+  } = useMediaPlayer()
+
+  const handleClickPlayer = ({ target }: MouseEvent) => {
+    if (isPending) {
+      return
+    }
+
+    if (!(target instanceof HTMLElement)) {
+      return
+    }
+
+    const { clickType } = target.dataset
+
+    if (clickType === "play" || clickType === "mute") {
+      onClickPlayer({ type: clickType })
+    }
+  }
+
+  const onChangeRangeInput = ({ target }: ChangeEvent) => {
+    if (isPending) {
+      return
+    }
+
+    if (!(target instanceof HTMLInputElement)) {
+      return
+    }
+
+    const { value, dataset } = target
+    const { changeType } = dataset
+    const convertedValue = parseFloat(value)
+    if (!changeType) {
+      return
+    }
+
+    if (changeType === "volume" || changeType === "play") {
+      onChangeRange({ type: changeType, percentage: convertedValue })
+    }
+  }
+
+  return (
+    <ul>
+      <li>
+        <ReactPlayer
+          url={playUrl}
+          ref={playerRef}
+          playing={isPending ? false : isPlaying}
+          muted={isPending ? true : isMute}
+          volume={isPending ? 0 : volume}
+          config={{
+            youtube: {
+              playerVars: {
+                origin: window.location.origin,
+              },
+            },
+          }}
+        />
+      </li>
+      <li>
+        <button
+          onClick={handleClickPlayer}
+          data-click-type="play"
+        >
+          상태 변경 테스트를 위한 플레이 버튼 {`${isPlaying}`}
+        </button>
+      </li>
+
+      <li
+        onClick={handleClickPlayer}
+        data-click-type="mute"
+      >
+        뮤트 변경 테스트를 위한 플레이 버튼
+      </li>
+
+      <li>
+        <input
+          type={"range"}
+          data-change-type="play"
+          value={playRange}
+          step="any"
+          min={0}
+          max={1}
+          onChange={onChangeRangeInput}
+        />
+      </li>
+
+      <li>
+        <input
+          type={"range"}
+          data-change-type="volume"
+          value={volume}
+          step="any"
+          min={0}
+          max={1}
+          onChange={onChangeRangeInput}
+        />
+      </li>
+
+      <button
+        onClick={() =>
+          onChangeUrl("https://www.youtube.com/watch?v=2gliGzb2_1I&t=3642s")
+        }
+      >
+        ChangeURL
+      </button>
+    </ul>
+  )
+}
+
+export default Player

--- a/src/components/MediaPlayer/components/Player.tsx
+++ b/src/components/MediaPlayer/components/Player.tsx
@@ -1,8 +1,14 @@
-import { ChangeEvent, MouseEvent } from "react"
+import { ChangeEvent, MouseEvent, useEffect } from "react"
 import useMediaPlayer from "../hooks/useMediaPlayer"
 import ReactPlayer from "react-player"
 
-const Player = ({ isPending = true }: { isPending?: boolean }) => {
+const Player = ({
+  isBlock = false,
+  url,
+}: {
+  isBlock?: boolean
+  url: string
+}) => {
   const {
     playUrl,
     playerRef,
@@ -15,8 +21,12 @@ const Player = ({ isPending = true }: { isPending?: boolean }) => {
     onChangeUrl,
   } = useMediaPlayer()
 
+  useEffect(() => {
+    onChangeUrl(url)
+  }, [onChangeUrl, url])
+
   const handleClickPlayer = ({ target }: MouseEvent) => {
-    if (isPending) {
+    if (isBlock) {
       return
     }
 
@@ -32,7 +42,7 @@ const Player = ({ isPending = true }: { isPending?: boolean }) => {
   }
 
   const onChangeRangeInput = ({ target }: ChangeEvent) => {
-    if (isPending) {
+    if (isBlock) {
       return
     }
 
@@ -58,9 +68,9 @@ const Player = ({ isPending = true }: { isPending?: boolean }) => {
         <ReactPlayer
           url={playUrl}
           ref={playerRef}
-          playing={isPending ? false : isPlaying}
-          muted={isPending ? true : isMute}
-          volume={isPending ? 0 : volume}
+          playing={isBlock ? false : isPlaying}
+          muted={isBlock ? true : isMute}
+          volume={isBlock ? 0 : volume}
           config={{
             youtube: {
               playerVars: {
@@ -68,6 +78,7 @@ const Player = ({ isPending = true }: { isPending?: boolean }) => {
               },
             },
           }}
+          style={{ display: "none" }}
         />
       </li>
       <li>
@@ -90,7 +101,7 @@ const Player = ({ isPending = true }: { isPending?: boolean }) => {
         <input
           type={"range"}
           data-change-type="play"
-          value={playRange}
+          value={isBlock ? 0 : playRange}
           step="any"
           min={0}
           max={1}
@@ -102,7 +113,7 @@ const Player = ({ isPending = true }: { isPending?: boolean }) => {
         <input
           type={"range"}
           data-change-type="volume"
-          value={volume}
+          value={isBlock ? 0 : volume}
           step="any"
           min={0}
           max={1}

--- a/src/components/MediaPlayer/constants/mediaPlayer.ts
+++ b/src/components/MediaPlayer/constants/mediaPlayer.ts
@@ -1,0 +1,6 @@
+export const PROGRESS_BAR_RANGE_PERCENTAGE = {
+  MIN: 0,
+  MAX: 1,
+}
+
+export const MEDIA_PLAYER_EMPTY_URL_KEYWORD = "this is other Page"

--- a/src/components/MediaPlayer/hooks/useMediaPlayer.ts
+++ b/src/components/MediaPlayer/hooks/useMediaPlayer.ts
@@ -1,0 +1,78 @@
+import useMediaPlayerStore from "@/components/MediaPlayer/store/useMediaPlayerStore"
+import { useRef } from "react"
+import ReactPlayer from "react-player"
+import {
+  ChangePlayer,
+  ChangeUrl,
+  TogglePlayer,
+} from "../store/useMediaPlayerStore.Types"
+import {
+  MEDIA_PLAYER_EMPTY_URL_KEYWORD,
+  PROGRESS_BAR_RANGE_PERCENTAGE,
+} from "../constants/MediaPlayer"
+
+const useMediaPlayer = () => {
+  const playerRef = useRef<ReactPlayer>(null)
+  const {
+    playUrl,
+    isMute,
+    isPlaying,
+    playRange,
+    volume,
+    togglePlayer,
+    changeRange,
+    changeUrl,
+  } = useMediaPlayerStore()
+
+  const onClickPlayer: TogglePlayer = (toggleType) => {
+    togglePlayer(toggleType)
+  }
+
+  const onChangeRange: ChangePlayer = ({ type, percentage }) => {
+    const { current } = playerRef
+
+    if (
+      !current &&
+      percentage < PROGRESS_BAR_RANGE_PERCENTAGE.MIN &&
+      percentage > PROGRESS_BAR_RANGE_PERCENTAGE.MAX
+    ) {
+      return
+    }
+
+    if (!(current instanceof ReactPlayer)) {
+      return
+    }
+
+    changeRange({ type, percentage })
+
+    if (type === "play") {
+      current.seekTo(percentage)
+    }
+  }
+
+  const onChangeUrl: ChangeUrl = (url) => {
+    if (url === MEDIA_PLAYER_EMPTY_URL_KEYWORD) {
+      changeUrl("")
+      return
+    }
+
+    const isCanPlay = ReactPlayer.canPlay(url)
+    if (isCanPlay) {
+      changeUrl(url)
+    }
+  }
+
+  return {
+    playUrl,
+    isPlaying,
+    isMute,
+    playerRef,
+    playRange,
+    volume,
+    onClickPlayer,
+    onChangeRange,
+    onChangeUrl,
+  }
+}
+
+export default useMediaPlayer

--- a/src/components/MediaPlayer/hooks/useMediaPlayer.ts
+++ b/src/components/MediaPlayer/hooks/useMediaPlayer.ts
@@ -51,6 +51,7 @@ const useMediaPlayer = () => {
   }
 
   const onChangeUrl: ChangeUrl = (url) => {
+    // 이후 EditPage 에서의 player의 초기화를 위한 조건 - 해당 주석 다음 PR에서 제거 예정
     if (url === MEDIA_PLAYER_EMPTY_URL_KEYWORD) {
       changeUrl("")
       return

--- a/src/components/MediaPlayer/store/useMediaPlayerStore.Types.ts
+++ b/src/components/MediaPlayer/store/useMediaPlayerStore.Types.ts
@@ -1,0 +1,19 @@
+export type TogglePlayer = (params: { type: "play" | "mute" }) => void
+
+export type ChangePlayer = (params: {
+  type: "play" | "volume"
+  percentage: number
+}) => void
+
+export type ChangeUrl = (params: { url: string }) => void
+
+export interface UseMediaPlayerStore {
+  playUrl: string
+  isPlaying: boolean
+  isMute: boolean
+  playRange: number
+  volume: number
+  togglePlayer: TogglePlayer
+  changeRange: ChangePlayer
+  changeUrl: ChangeUrl
+}

--- a/src/components/MediaPlayer/store/useMediaPlayerStore.Types.ts
+++ b/src/components/MediaPlayer/store/useMediaPlayerStore.Types.ts
@@ -5,7 +5,7 @@ export type ChangePlayer = (params: {
   percentage: number
 }) => void
 
-export type ChangeUrl = (params: { url: string }) => void
+export type ChangeUrl = (url: string) => void
 
 export interface UseMediaPlayerStore {
   playUrl: string

--- a/src/components/MediaPlayer/store/useMediaPlayerStore.ts
+++ b/src/components/MediaPlayer/store/useMediaPlayerStore.ts
@@ -1,0 +1,51 @@
+import { create } from "zustand"
+import { devtools } from "zustand/middleware"
+import { UseMediaPlayerStore } from "./useMediaPlayerStore.Types"
+
+const useMediaPlayerStore = create<UseMediaPlayerStore>()(
+  devtools((set) => ({
+    playUrl: "https://www.youtube.com/watch?v=gwcw5S9HSUE",
+    isPlaying: false,
+    isMute: false,
+    playRange: 0,
+    volume: 0.2,
+
+    togglePlayer: ({ type }) => {
+      if (type === "play") {
+        set((store) => ({
+          ...store,
+          isPlaying: !store.isPlaying,
+        }))
+      }
+
+      if (type === "mute") {
+        set((store) => ({
+          ...store,
+          isMute: !store.isMute,
+        }))
+      }
+    },
+
+    changeRange: ({ type, percentage }) => {
+      if (type === "play") {
+        set((store) => ({
+          ...store,
+          playRange: percentage,
+        }))
+      }
+
+      if (type === "volume") {
+        set((store) => ({
+          ...store,
+          volume: percentage,
+        }))
+      }
+    },
+
+    changeUrl: ({ url }) => {
+      set((store) => ({ ...store, playUrl: url }))
+    },
+  })),
+)
+
+export default useMediaPlayerStore

--- a/src/components/MediaPlayer/store/useMediaPlayerStore.ts
+++ b/src/components/MediaPlayer/store/useMediaPlayerStore.ts
@@ -4,8 +4,8 @@ import { UseMediaPlayerStore } from "./useMediaPlayerStore.Types"
 
 const useMediaPlayerStore = create<UseMediaPlayerStore>()(
   devtools((set) => ({
-    playUrl: "https://www.youtube.com/watch?v=gwcw5S9HSUE",
-    isPlaying: false,
+    playUrl: "",
+    isPlaying: true,
     isMute: false,
     playRange: 0,
     volume: 0.2,
@@ -42,7 +42,7 @@ const useMediaPlayerStore = create<UseMediaPlayerStore>()(
       }
     },
 
-    changeUrl: ({ url }) => {
+    changeUrl: (url) => {
       set((store) => ({ ...store, playUrl: url }))
     },
   })),


### PR DESCRIPTION
## #️⃣연관된 이슈

close #90 

## 💡 핵심적으로 구현된 사항

- Player의 재생 상태를 전역적으로 담을 Store구현
  - 해당 Store의 액션은 순수하게 state를 업데이트 시키는 용도로 구현되었습니다.
  - store의 별도 사용 이유는 서비스 자체의 안정성에서는 하나의 상태만 존재하고 그 상태에 의존해 음악을 재생하는 방향이 안전하다고 판단했습니다.
- useMediaPlayer hook을 구현해 내부의 조건을 수행함
  - 변경해야할 상태가 많다보니 custom type과 dataset을 통해 변경되어지는 값을 업데이트 시키는 방향을 선택했습니다.
  - 내부 Url을 변경시키는 onChangeUrl 내부의 상수값을 통한 조건문은 추후 EditPage에서 url을 초기화 시키기 위한 기능입니다.


## ➕ 그 외에 추가적으로 구현된 사항

- 다음 작업에서 제대로 구현하게될 player의 내부 기능을 테스트겸 구현했습니다.
  - isBlock 이라는 prop은 조작이 가능한 Player가 아닐시( main card가 아닌 sub card ) 동작이 불가능 하도록  방어하기 위한 값으로 사용했습니다.
  - ReactPlayer의 config값은 postMessage에러를 최소화 해주기 위한 방법으로 별도 변수에 담아 사용이 불가능해 내부에서 사용했습니다.


## 🤔 테스트,검증 && 고민 사항


### 📌 PR Comment 작성 시 Prefix for Reviewers

<!-- * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
* P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
* P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore) -->
