### PR TITLE
[Feat ✏️] 조건부 라우팅 & persist 도입

### DIFF
--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -3,27 +3,27 @@ import * as S from "./Navbar.Styles"
 import NavbarLeftList from "./components/NavbarLeftList/NavbarLeftList"
 import NavbarRightList from "./components/NavbarRightList/NavbarRightList"
 
+const checkPathName = (path: string) => {
+  if (path.includes("useredit") || path.includes("signup")) {
+    return false
+  } else if (path.includes("login")) {
+    return "login"
+  }
+  return true
+}
+
 const Navbar = () => {
-  if (!checkPathName(useLocation().pathname)) {
+  const NavbarFlag = checkPathName(useLocation().pathname)
+  if (!NavbarFlag) {
     return
   }
 
   return (
     <S.NavbarLayout>
       <NavbarLeftList />
-      <NavbarRightList />
+      {NavbarFlag !== "login" && <NavbarRightList />}
     </S.NavbarLayout>
   )
-}
-
-const checkPathName = (path: string) => {
-  // 404페이지에서도 Navbar를 보여준다 가정
-  switch (path) {
-    case "useredit":
-      return false
-    default:
-      return true
-  }
 }
 
 export default Navbar

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -6,22 +6,28 @@ import NavbarRightList from "./components/NavbarRightList/NavbarRightList"
 const checkPathName = (path: string) => {
   if (path.includes("useredit") || path.includes("signup")) {
     return false
-  } else if (path.includes("login")) {
+  }
+
+  if (path.includes("login")) {
     return "login"
   }
+
   return true
 }
 
 const Navbar = () => {
-  const NavbarFlag = checkPathName(useLocation().pathname)
+  const { pathname } = useLocation()
+  const NavbarFlag = checkPathName(pathname)
   if (!NavbarFlag) {
     return
   }
 
+  const isLoginPage = NavbarFlag === "login"
+
   return (
     <S.NavbarLayout>
       <NavbarLeftList />
-      {NavbarFlag !== "login" && <NavbarRightList />}
+      {!isLoginPage && <NavbarRightList />}
     </S.NavbarLayout>
   )
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

close #130 

## 💡 핵심적으로 구현된 사항

- 페이지에 따라 Navbar를 다르게 보여줌(회원가입 페이지는 Navbar가 없고, 로그인 페이지에서는 왼쪽 부분만 보입니다.)
  - 인증확인으로 재로그인을 구현하려했는데 종욱님 말씀처럼 페이지마다 조건을 걸어야하기도해서 간편하게 persist를 이용했습니다.
- persist를 도입해 새로고침 시 로그인 상태값을 가지고 있어서 로그인이 풀리지 않도록 하였습니다.(세션스토리지 이용)
  - **크게 추가된건 없고 persist의 옵션 부분만 보면됩니다!! 마지막 인수 3개가 각각(persist의 storage를 사용할때 사용되는 고유한 이름, 어디 스토리지에 저장할지(기본값은 로컬스토리지), 부분적으로 인자를 저장하는 기능**

<!-- 문제를 해결하면서 주요하게 변경된 사항들을 "스크린샷"과 함께 적어 주세요 -->

## ➕ 그 외에 추가적으로 구현된 사항

<!-- 없으면 "없음" 이라고 기재해 주세요 -->
<!-- 주 Task 이외의 작업한 변경 사항  -->

## 🤔 테스트,검증 && 고민 사항

조건에 따라 Navbar를 다르게 보이게 하는 부분 코드가 조금 어색한 것 같습니다.. 더 이쁘게 짤 수 있을 것 같은데 어떻게 할까요..?!
<!-- 배포에서 체크해봐야 할 부분 -->
<!-- 궁금한 점, 팀원들의 의견이 필요한 부분, 크로스체크가 필요한 부분 등 -->

### 📌 PR Comment 작성 시 Prefix for Reviewers

<!-- * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
* P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
* P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore) -->
