### PR TITLE
[SearchModal] search bar 구현

### DIFF
--- a/src/components/Modal/Modal.Styles.ts
+++ b/src/components/Modal/Modal.Styles.ts
@@ -8,7 +8,7 @@ export const ModalBackground = styled.section`
   align-items: center;
   justify-content: center;
 
-  position: absolute;
+  position: fixed;
   top: 0;
 
   z-index: ${({ theme }) => theme.zIndex.modalBackground};

--- a/src/components/Search/Search.Constants.ts
+++ b/src/components/Search/Search.Constants.ts
@@ -1,0 +1,3 @@
+export const SEARCH_INPUT_BAR_CHANGE_TIMER_DELAY = 300
+
+export const SEARCH_INPUT_BAR_PLACEHOLDER = "사용자나 게시물을 검색해보세요"

--- a/src/components/Search/components/SearchInput/SearchInput.tsx
+++ b/src/components/Search/components/SearchInput/SearchInput.tsx
@@ -1,12 +1,12 @@
 import * as S from "./SearchInput.Styles"
-import { SearchInputBarLayout } from "./components/SearchInputBar/SearchInputBar.Styles"
-import { SearchInputFilterLayout } from "./components/SearchInputFilter/SearchInputFilter.Styles"
+import SearchInputBar from "./components/SearchInputBar/SearchInputBar"
+import SearchInputFilter from "./components/SearchInputFilter/SearchInputFilter"
 
 const SearchInput = () => {
   return (
     <S.SearchInputLayout>
-      <SearchInputFilterLayout />
-      <SearchInputBarLayout />
+      <SearchInputFilter />
+      <SearchInputBar />
     </S.SearchInputLayout>
   )
 }

--- a/src/components/Search/components/SearchInput/components/SearchInputBar/SearchInputBar.Styles.ts
+++ b/src/components/Search/components/SearchInput/components/SearchInputBar/SearchInputBar.Styles.ts
@@ -14,6 +14,12 @@ export const SearchBarForm = styled.form`
 export const SearchBarInput = styled.input`
   width: 100%;
 
+  //chrome이 제공하는 input 자동완성의 백그라운드 지정
+  &:-webkit-autofill {
+    -webkit-box-shadow: 0 0 0 100rem ${({ theme }) => theme.colors.white} inset !important;
+    -webkit-text-fill-color: ${({ theme }) => theme.colors.black} !important;
+  }
+
   &::placeholder {
     color: ${({ theme }) => theme.colors.gray40};
   }
@@ -30,10 +36,7 @@ export const SearchBarInput = styled.input`
     cursor: pointer;
   }
 
-  &::-webkit-search-decoration,
-  &::-webkit-search-cancel-button,
-  &::-webkit-search-results-button,
-  &::-webkit-search-results-decoration {
+  &::-webkit-search-cancel-button {
     cursor: pointer;
   }
 `

--- a/src/components/Search/components/SearchInput/components/SearchInputBar/SearchInputBar.Styles.ts
+++ b/src/components/Search/components/SearchInput/components/SearchInputBar/SearchInputBar.Styles.ts
@@ -1,6 +1,44 @@
 import styled from "styled-components"
 
-export const SearchInputBarLayout = styled.div`
+export const SearchBarForm = styled.form`
+  display: flex;
   width: 100%;
-  background-color: ${({ theme }) => theme.colors.black};
+  padding: 1.4rem;
+
+  border-radius: 1rem;
+  border: ${({ theme }) => `0.1rem solid ${theme.colors.sub}`};
+
+  background-color: ${({ theme }) => theme.colors.white};
+`
+
+export const SearchBarInput = styled.input`
+  width: 100%;
+
+  &::placeholder {
+    color: ${({ theme }) => theme.colors.gray40};
+  }
+
+  font-size: ${({ theme }) => theme.fontSizes.large};
+
+  /* (다음 Pr에서 주석 삭제 예정)
+   검색어를 입력하면 검색바 오른쪽 끝에 나오는 x자 버튼입니다.
+   위 : IE, 
+   아래 : Chrome
+  */
+  &::-ms-clear,
+  &::-ms-reveal {
+    cursor: pointer;
+  }
+
+  &::-webkit-search-decoration,
+  &::-webkit-search-cancel-button,
+  &::-webkit-search-results-button,
+  &::-webkit-search-results-decoration {
+    cursor: pointer;
+  }
+`
+export const SearchIconLayout = styled.div`
+  svg {
+    font-size: 3rem;
+  }
 `

--- a/src/components/Search/components/SearchInput/components/SearchInputBar/SearchInputBar.tsx
+++ b/src/components/Search/components/SearchInput/components/SearchInputBar/SearchInputBar.tsx
@@ -2,30 +2,39 @@ import { API } from "@/apis/Api"
 import * as S from "./SearchInputBar.Styles"
 import { useState } from "react"
 import { Search } from "@mui/icons-material"
+import {
+  SEARCH_INPUT_BAR_PLACEHOLDER,
+  SEARCH_INPUT_BAR_CHANGE_TIMER_DELAY,
+} from "@/components/Search/Search.Constants"
 
 const SearchInputBar = () => {
-  const [input, setInput] = useState("")
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
+  const [searchKeyword, setSearchKeyword] = useState("")
 
-    // filter 컴포넌트, result 컴포넌트 작업 후 수정 예정
-    const { data } = await API.get(`/search/all/${input}`)
-    console.log(data)
-  }
-
+  let timer: number | null | undefined = null
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setInput(e.target.value)
+    if (timer) {
+      clearTimeout(timer)
+    }
+
+    timer = setTimeout(async () => {
+      setSearchKeyword(e.target.value)
+
+      if (e.target.value) {
+        const { data } = await API.get(`/search/all/${e.target.value}`)
+        console.log(data)
+      }
+    }, SEARCH_INPUT_BAR_CHANGE_TIMER_DELAY)
   }
 
   return (
-    <S.SearchBarForm onSubmit={handleSubmit}>
+    <S.SearchBarForm onSubmit={(e) => e.preventDefault()}>
       <S.SearchBarInput
         type="search"
-        placeholder="사용자나 게시물을 검색해보세요"
+        placeholder={SEARCH_INPUT_BAR_PLACEHOLDER}
         name="searchbar"
         onChange={handleInputChange}
       />
-      {!input && (
+      {!searchKeyword && (
         <S.SearchIconLayout>
           <Search />
         </S.SearchIconLayout>

--- a/src/components/Search/components/SearchInput/components/SearchInputBar/SearchInputBar.tsx
+++ b/src/components/Search/components/SearchInput/components/SearchInputBar/SearchInputBar.tsx
@@ -1,7 +1,37 @@
+import { API } from "@/apis/Api"
 import * as S from "./SearchInputBar.Styles"
+import { useState } from "react"
+import { Search } from "@mui/icons-material"
 
 const SearchInputBar = () => {
-  return <S.SearchInputBarLayout>SearchInputBar</S.SearchInputBarLayout>
+  const [input, setInput] = useState("")
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+
+    // filter 컴포넌트, result 컴포넌트 작업 후 수정 예정
+    const { data } = await API.get(`/search/all/${input}`)
+    console.log(data)
+  }
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setInput(e.target.value)
+  }
+
+  return (
+    <S.SearchBarForm onSubmit={handleSubmit}>
+      <S.SearchBarInput
+        type="search"
+        placeholder="사용자나 게시물을 검색해보세요"
+        name="searchbar"
+        onChange={handleInputChange}
+      />
+      {!input && (
+        <S.SearchIconLayout>
+          <Search />
+        </S.SearchIconLayout>
+      )}
+    </S.SearchBarForm>
+  )
 }
 
 export default SearchInputBar

--- a/src/components/Search/components/SearchInput/components/SearchInputFilter/SearchInputFilter.Styles.ts
+++ b/src/components/Search/components/SearchInput/components/SearchInputFilter/SearchInputFilter.Styles.ts
@@ -1,6 +1,6 @@
 import styled from "styled-components"
 
-export const SearchInputFilterLayout = styled.div`
+export const SearchFilterInput = styled.select`
   width: 10rem;
   background-color: ${({ theme }) => theme.colors.white};
 `

--- a/src/components/Search/components/SearchInput/components/SearchInputFilter/SearchInputFilter.tsx
+++ b/src/components/Search/components/SearchInput/components/SearchInputFilter/SearchInputFilter.tsx
@@ -1,9 +1,7 @@
 import * as S from "./SearchInputFilter.Styles"
 
 const SearchInputFilter = () => {
-  return (
-    <S.SearchInputFilterLayout>SearchInputFilter</S.SearchInputFilterLayout>
-  )
+  return <S.SearchFilterInput></S.SearchFilterInput>
 }
 
 export default SearchInputFilter


### PR DESCRIPTION
## #️⃣연관된 이슈
close #54 
<!-- #이슈번호, #이슈번호-->

## 💡 핵심적으로 구현된 사항
<검색 전>
<img width="1558" alt="스크린샷 2024-01-10 오후 1 51 43" src="https://github.com/prgrms-fe-devcourse/FEDC5_Yap_YUNHO/assets/68155263/75f6ee03-de88-434b-88c8-b74400a4217a">
<검색 후>
<img width="1512" alt="스크린샷 2024-01-10 오후 1 51 16" src="https://github.com/prgrms-fe-devcourse/FEDC5_Yap_YUNHO/assets/68155263/357199d1-46b7-430d-88af-17fb58474f91">
- 서치바 검색 기능을 구현했습니다(api 통신까지)
- 현재는 all에서 검색하고 결과를 console하도록만 했습니다


## ➕ 그 외에 추가적으로 구현된 사항
- 유저페이지처럼 스크롤이 생기는 페이지에서 modal 백그라운드가 페이지 전체를 덮지 못하는 이슈를 수정
- search filter 스타일 변경
<!-- 없으면 "없음" 이라고 기재해 주세요 -->
<!-- 주 Task 이외의 작업한 변경 사항  -->

## 🤔 테스트,검증 && 고민 사항
- 모달이 켜졌을 때 뒤에 있는 페이지 스크롤을 막아야 할 것 같습니닷
지금 생각나는건 서치모달도 스토어로 만들어서 모달이 켜졌을 때를 감지해 페이지 스크롤을 막으면 될 것 같아요
<!-- 배포에서 체크해봐야 할 부분 -->
<!-- 궁금한 점, 팀원들의 의견이 필요한 부분, 크로스체크가 필요한 부분 등 -->

### 📌 PR Comment 작성 시 Prefix for Reviewers

<!-- * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
* P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
* P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore) -->
