### PR TITLE
[Fix 🪛] search의 react-query isError 처리 위치 변경

### DIFF
--- a/src/components/SearchModal/hooks/useSearchResult.ts
+++ b/src/components/SearchModal/hooks/useSearchResult.ts
@@ -45,13 +45,13 @@ const useSearchResult = (keyword: string) => {
         }
       })
 
-      if (isError) {
-        return []
-      }
-
       return resultList
     },
   })
+
+  if (isError) {
+    return []
+  }
 
   return data
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- #이슈번호, #이슈번호-->

## 💡 핵심적으로 구현된 사항
- react-query의 isError를 select에서 처리하니 선언 전에 참조했다는 에러가 뜨면서 isError가 항상 true가 되는 문제를 수정했습니다
- 리뷰 반영하고 한번 더 확인 못한 저의 불찰입니다.....
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 "스크린샷"과 함께 적어 주세요 -->

## ➕ 그 외에 추가적으로 구현된 사항

<!-- 없으면 "없음" 이라고 기재해 주세요 -->
<!-- 주 Task 이외의 작업한 변경 사항  -->

## 🤔 테스트,검증 && 고민 사항

<!-- 배포에서 체크해봐야 할 부분 -->
<!-- 궁금한 점, 팀원들의 의견이 필요한 부분, 크로스체크가 필요한 부분 등 -->

### 📌 PR Comment 작성 시 Prefix for Reviewers

<!-- * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
* P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
* P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore) -->
