### PR TITLE
[UserPage] 유저 페이지의 프로필 영역에 API 데이터 주입

### DIFF
--- a/src/components/Navbar/components/NavbarRightList/NavbarRightList.tsx
+++ b/src/components/Navbar/components/NavbarRightList/NavbarRightList.tsx
@@ -15,7 +15,7 @@ import useMenuClick from "../../hooks/useNavMenuClick"
 import CloseIcon from "@mui/icons-material/Close"
 
 const NavbarRightList = () => {
-  const { isLoggedIn } = useAuthUserStore()
+  const { isLoggedIn, myId } = useAuthUserStore()
   const { isToggle, toggleRef, handleToggle } = useToggle()
   const { handleMenuClick, PostEditModal } = useMenuClick()
 
@@ -47,7 +47,7 @@ const NavbarRightList = () => {
       {/* 프로필 버튼*/}
       <NavbarButton
         onClick={() => {
-          navigate("/profile")
+          navigate(`/profile/${myId}`)
         }}
       >
         <S.NavbarProfile

--- a/src/components/PostDetail/components/PostDetailInfo/components/PostDetailStatus/PostDetailStatus.tsx
+++ b/src/components/PostDetail/components/PostDetailInfo/components/PostDetailStatus/PostDetailStatus.tsx
@@ -1,6 +1,6 @@
 import * as S from "./PostDetailStatus.Styles"
 import { Like, Post, User } from "@/types"
-import { convertFollowCount } from "@/util/convertFollowCount"
+import { getConvertedCount } from "@/util/getConvertedCount"
 import PostDetailEditActions from "./components/PostDetailEditActions"
 import ThumbUpOffAltIcon from "@mui/icons-material/ThumbUpOffAlt"
 import ThumbUpAltIcon from "@mui/icons-material/ThumbUpAlt"
@@ -94,7 +94,7 @@ const PostDetailStatus = ({
               <ThumbUpOffAltIcon />
             )}
 
-            {convertFollowCount(likes.length)}
+            {getConvertedCount(likes.length)}
           </S.PostDetailLike>
 
           <S.PostDetailLink

--- a/src/components/PostDetail/components/PostDetailInfo/components/PostDetailUser/PostDetailUser.tsx
+++ b/src/components/PostDetail/components/PostDetailInfo/components/PostDetailUser/PostDetailUser.tsx
@@ -1,6 +1,6 @@
 import { Post } from "@/types"
 import * as S from "./PostDetailUser.Styles"
-import { convertFollowCount } from "@/util/convertFollowCount"
+import { getConvertedCount } from "@/util/getConvertedCount"
 import useAuthUserStore from "@/stores/useAuthUserStore"
 import useFetchFollow from "@/hooks/useFetchFollow"
 import useFetchUnFollow from "@/hooks/useFetchUnFollow"
@@ -17,7 +17,7 @@ const PostDetailUser = ({ post, isMyPost }: PostDetailInfoUserProps) => {
 
   const { author } = post
   const { image, fullName, followers } = author
-  const followerCount = convertFollowCount(followers.length)
+  const followerCount = getConvertedCount(followers.length)
 
   const hasFollowingData = user.following.find(
     (following) => following.user === author._id,

--- a/src/components/UserInfoPopover/Components/UserInfoFollowStatus/UserInfoFollowStatus.tsx
+++ b/src/components/UserInfoPopover/Components/UserInfoFollowStatus/UserInfoFollowStatus.tsx
@@ -1,6 +1,6 @@
 import { User } from "@/types"
 import * as S from "./UserInfoFollowStatus.Styles"
-import { convertFollowCount } from "@/util/convertFollowCount"
+import { getConvertedCount } from "@/util/getConvertedCount"
 
 interface UserInfoFollowStatusProps {
   user: User
@@ -9,8 +9,8 @@ interface UserInfoFollowStatusProps {
 const UserInfoFollowStatus = ({ user }: UserInfoFollowStatusProps) => {
   const { followers, following } = user
 
-  const convertedFollowingCount = convertFollowCount(following.length)
-  const convertedFollowerCount = convertFollowCount(followers.length)
+  const convertedFollowingCount = getConvertedCount(following.length)
+  const convertedFollowerCount = getConvertedCount(followers.length)
   return (
     <S.UserInfoFollowStatusLayout>
       <S.UserInfoFollowStatus>{`팔로잉 ${convertedFollowingCount} 명`}</S.UserInfoFollowStatus>

--- a/src/constants/errorMessage.ts
+++ b/src/constants/errorMessage.ts
@@ -46,3 +46,6 @@ export const POST_DETAIL_ERROR_MESSAGE = {
     COMMENT: "올바른 댓글을 작성해주세요!",
   },
 }
+
+export const USER_PAGE_ERROR_MESSAGE =
+  "오류가 발생했습니다.\n 다시 시도 해주세요"

--- a/src/constants/modalMessage.ts
+++ b/src/constants/modalMessage.ts
@@ -26,3 +26,5 @@ export const POST_DETAIL_MODAL_MESSAGE = {
     COMMENT_DELETE: "댓글이 삭제되었습니다!",
   },
 }
+
+export const NOT_LOGIN_MODAL_MESSAGE = "로그인 후 이용 가능합니다."

--- a/src/pages/Profile/components/UserProfile/UserActions/UserFollowButton.tsx
+++ b/src/pages/Profile/components/UserProfile/UserActions/UserFollowButton.tsx
@@ -1,7 +1,0 @@
-import * as S from "@/pages/Profile/Profile.Styles"
-
-const UserFollowButton = () => {
-  return <S.UserInfoButton>팔로우</S.UserInfoButton>
-}
-
-export default UserFollowButton

--- a/src/pages/Profile/components/UserProfile/UserActions/UserSendDMButton.tsx
+++ b/src/pages/Profile/components/UserProfile/UserActions/UserSendDMButton.tsx
@@ -1,7 +1,0 @@
-import * as S from "@/pages/Profile/Profile.Styles"
-
-const UserSendDMButton = () => {
-  return <S.UserInfoButton>DM 보내기</S.UserInfoButton>
-}
-
-export default UserSendDMButton

--- a/src/pages/Profile/components/UserProfile/UserActions/UserUpdateInfoButton.tsx
+++ b/src/pages/Profile/components/UserProfile/UserActions/UserUpdateInfoButton.tsx
@@ -1,7 +1,0 @@
-import * as S from "@/pages/Profile/Profile.Styles"
-
-const UserUpdateInfoButton = () => {
-  return <S.UserInfoButton>회원 정보 수정</S.UserInfoButton>
-}
-
-export default UserUpdateInfoButton

--- a/src/pages/Profile/components/UserProfile/UserProfile.Styles.ts
+++ b/src/pages/Profile/components/UserProfile/UserProfile.Styles.ts
@@ -11,7 +11,7 @@ export const UserProfileLayout = styled.section`
   padding: 4rem 0;
   border-bottom: 0.1rem solid;
 `
-export const UserProfileImageContainer = styled.div`
+export const UserProfileImageContainer = styled.img`
   height: 16rem;
   width: 16rem;
   border-radius: ${({ theme }) => theme.radius.circle};

--- a/src/pages/Profile/components/UserProfile/UserProfile.tsx
+++ b/src/pages/Profile/components/UserProfile/UserProfile.tsx
@@ -14,12 +14,10 @@ const UserProfile = () => {
   const [followerCount, setFollowerCount] = useState(0)
 
   useEffect(() => {
-    AUTH_API.get(`/users/${id}`)
-      .then((res) => res.data)
-      .then((data) => {
-        setUserInfo(data)
-        setFollowerCount(data.followers.length)
-      })
+    AUTH_API.get(`/users/${id}`).then((res) => {
+      setUserInfo(res.data)
+      setFollowerCount(res.data.followers.length)
+    })
   }, [id, setUserInfo])
 
   return (

--- a/src/pages/Profile/components/UserProfile/UserProfile.tsx
+++ b/src/pages/Profile/components/UserProfile/UserProfile.tsx
@@ -4,12 +4,18 @@ import UserFollowInfo from "./components/UserFollowInfo/UserFollowInfo"
 import UserNickname from "./components/UserNickname"
 import UserProfileImage from "./components/UserProfileImage"
 import { AUTH_API } from "@/apis/Api"
-import { useParams } from "react-router-dom"
+import { useNavigate, useParams } from "react-router-dom"
 import { useQuery } from "@tanstack/react-query"
+import AlertModal from "@/components/Modal/components/AlertModal/AlertModal"
+import { USER_PAGE_ERROR_MESSAGE } from "@/constants/errorMessage"
+import useModal from "@/components/Modal/hooks/useModal"
 
 const USER_PROFILE_QUERY_KEY = "USER_PROFILE_QUERY_KEY"
 
 const UserProfile = () => {
+  const navigate = useNavigate()
+  const { isShowModal, showModal, closeModal } = useModal()
+
   const { id } = useParams()
 
   const { data, isLoading, isError } = useQuery({
@@ -19,20 +25,36 @@ const UserProfile = () => {
     gcTime: 1000 * 60 * 10,
   })
 
-  if (isLoading || isError) {
+  const handleCloseErrorModal = () => {
+    navigate("/")
+    closeModal()
+  }
+
+  if (isError) {
+    showModal()
+  }
+
+  if (isLoading) {
     return
   }
 
   return (
-    <S.UserProfileLayout>
-      <UserProfileImage image={data.image} />
-      <UserNickname nickName={data.fullName} />
-      <UserActions />
-      <UserFollowInfo
-        followingCount={data.following.length}
-        followerCount={data.followers.length}
+    <>
+      <S.UserProfileLayout>
+        <UserProfileImage image={data.image} />
+        <UserNickname nickName={data.fullName} />
+        <UserActions />
+        <UserFollowInfo
+          followingCount={data.following.length}
+          followerCount={data.followers.length}
+        />
+      </S.UserProfileLayout>
+      <AlertModal
+        isShow={isShowModal}
+        alertMessage={USER_PAGE_ERROR_MESSAGE}
+        onClose={handleCloseErrorModal}
       />
-    </S.UserProfileLayout>
+    </>
   )
 }
 

--- a/src/pages/Profile/components/UserProfile/UserProfile.tsx
+++ b/src/pages/Profile/components/UserProfile/UserProfile.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from "react"
 import * as S from "./UserProfile.Styles"
 import UserActions from "./components/UserActions/UserActions"
 import UserFollowInfo from "./components/UserFollowInfo/UserFollowInfo"
@@ -6,31 +5,28 @@ import UserNickname from "./components/UserNickname"
 import UserProfileImage from "./components/UserProfileImage"
 import { AUTH_API } from "@/apis/Api"
 import { useParams } from "react-router-dom"
-import { User } from "@/types"
+import { useQuery } from "@tanstack/react-query"
 
 const UserProfile = () => {
   const { id } = useParams()
-  const [userInfo, setUserInfo] = useState<User>()
-  const [followerCount, setFollowerCount] = useState(0)
 
-  useEffect(() => {
-    AUTH_API.get(`/users/${id}`).then((res) => {
-      setUserInfo(res.data)
-      setFollowerCount(res.data.followers.length)
-    })
-  }, [id, setUserInfo])
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["1234", id],
+    queryFn: () => AUTH_API.get(`/users/${id}`).then((res) => res.data),
+  })
+
+  if (isLoading || isError) {
+    return
+  }
 
   return (
     <S.UserProfileLayout>
-      <UserProfileImage image={userInfo?.image} />
-      <UserNickname nickName={userInfo?.fullName} />
-      <UserActions
-        onFollowButtonClick={() => setFollowerCount((state) => state + 1)}
-        onUnFollowButtonClick={() => setFollowerCount((state) => state - 1)}
-      />
+      <UserProfileImage image={data.image} />
+      <UserNickname nickName={data.fullName} />
+      <UserActions />
       <UserFollowInfo
-        followingCount={userInfo?.following.length}
-        followerCount={followerCount}
+        followingCount={data.following.length}
+        followerCount={data.followers.length}
       />
     </S.UserProfileLayout>
   )

--- a/src/pages/Profile/components/UserProfile/UserProfile.tsx
+++ b/src/pages/Profile/components/UserProfile/UserProfile.tsx
@@ -7,12 +7,16 @@ import { AUTH_API } from "@/apis/Api"
 import { useParams } from "react-router-dom"
 import { useQuery } from "@tanstack/react-query"
 
+const USER_PROFILE_QUERY_KEY = "USER_PROFILE_QUERY_KEY"
+
 const UserProfile = () => {
   const { id } = useParams()
 
   const { data, isLoading, isError } = useQuery({
-    queryKey: ["1234", id],
+    queryKey: [USER_PROFILE_QUERY_KEY, id],
     queryFn: () => AUTH_API.get(`/users/${id}`).then((res) => res.data),
+    staleTime: 1000 * 60 * 5,
+    gcTime: 1000 * 60 * 10,
   })
 
   if (isLoading || isError) {

--- a/src/pages/Profile/components/UserProfile/UserProfile.tsx
+++ b/src/pages/Profile/components/UserProfile/UserProfile.tsx
@@ -1,16 +1,39 @@
+import { useEffect, useState } from "react"
 import * as S from "./UserProfile.Styles"
 import UserActions from "./components/UserActions/UserActions"
 import UserFollowInfo from "./components/UserFollowInfo/UserFollowInfo"
 import UserNickname from "./components/UserNickname"
 import UserProfileImage from "./components/UserProfileImage"
+import { AUTH_API } from "@/apis/Api"
+import { useParams } from "react-router-dom"
+import { User } from "@/types"
 
 const UserProfile = () => {
+  const { id } = useParams()
+  const [userInfo, setUserInfo] = useState<User>()
+  const [followerCount, setFollowerCount] = useState(0)
+
+  useEffect(() => {
+    AUTH_API.get(`/users/${id}`)
+      .then((res) => res.data)
+      .then((data) => {
+        setUserInfo(data)
+        setFollowerCount(data.followers.length)
+      })
+  }, [id, setUserInfo])
+
   return (
     <S.UserProfileLayout>
-      <UserProfileImage />
-      <UserNickname />
-      <UserActions />
-      <UserFollowInfo />
+      <UserProfileImage image={userInfo?.image} />
+      <UserNickname nickName={userInfo?.fullName} />
+      <UserActions
+        onFollowButtonClick={() => setFollowerCount((state) => state + 1)}
+        onUnFollowButtonClick={() => setFollowerCount((state) => state - 1)}
+      />
+      <UserFollowInfo
+        followingCount={userInfo?.following.length}
+        followerCount={followerCount}
+      />
     </S.UserProfileLayout>
   )
 }

--- a/src/pages/Profile/components/UserProfile/components/UserActions/UserActions.Styles.ts
+++ b/src/pages/Profile/components/UserProfile/components/UserActions/UserActions.Styles.ts
@@ -9,6 +9,7 @@ export const UserActionLayout = styled.section`
 
 export const UserActionButton = styled.button<{
   $width?: number
+  $isFollowing?: boolean
 }>`
   user-select: none;
 
@@ -18,7 +19,9 @@ export const UserActionButton = styled.button<{
   font-size: ${({ theme }) => theme.fontSizes.semiLarge};
 
   border-radius: ${({ theme }) => theme.radius.size8};
-  background-color: ${({ theme }) => theme.colors.point};
+  background-color: ${({ theme, $isFollowing }) =>
+    $isFollowing ? theme.colors.gray : theme.colors.point};
+
   &:hover {
     opacity: ${({ theme }) => theme.opacity.normal};
     transition: ${({ theme }) => theme.transition.normal};

--- a/src/pages/Profile/components/UserProfile/components/UserActions/UserActions.tsx
+++ b/src/pages/Profile/components/UserProfile/components/UserActions/UserActions.tsx
@@ -7,15 +7,7 @@ import ConfirmModal from "@/components/Modal/components/ConfirmModal/ConfirmModa
 import { NOT_LOGIN_MODAL_MESSAGE } from "@/constants/modalMessage"
 import useModal from "@/components/Modal/hooks/useModal"
 
-interface UserActionsProps {
-  onFollowButtonClick: () => void
-  onUnFollowButtonClick: () => void
-}
-
-const UserActions = ({
-  onFollowButtonClick,
-  onUnFollowButtonClick,
-}: UserActionsProps) => {
+const UserActions = () => {
   const navigate = useNavigate()
   const { isShowModal, showModal, closeModal } = useModal()
 
@@ -28,7 +20,6 @@ const UserActions = ({
       showModal()
       return
     }
-    console.log(isDMPage)
 
     if (isDMPage) {
       navigate(`/directmessage/${id}`)
@@ -54,11 +45,7 @@ const UserActions = ({
         />
       ) : (
         <>
-          <UserFollowActionButton
-            onFollowButtonClick={onFollowButtonClick}
-            onUnFollowButtonClick={onUnFollowButtonClick}
-            onClick={handleClickButton}
-          />
+          <UserFollowActionButton onClick={handleClickButton} />
           <UserActionButton
             text="DM 보내기"
             $width={9}

--- a/src/pages/Profile/components/UserProfile/components/UserActions/UserActions.tsx
+++ b/src/pages/Profile/components/UserProfile/components/UserActions/UserActions.tsx
@@ -1,12 +1,14 @@
 import * as S from "./UserActions.Styles"
-import { useParams } from "react-router-dom"
+import { useNavigate, useParams } from "react-router-dom"
 import useAuthUserStore from "@/stores/useAuthUserStore"
 import UserActionButton from "./UserActionButton"
+import UserFollowActionButton from "./UserFollowActionButton"
 
 const UserActions = () => {
+  const navigate = useNavigate()
   const { id } = useParams()
-  const { user } = useAuthUserStore()
-  const isMyPage = user._id === id
+  const { myId } = useAuthUserStore()
+  const isMyPage = myId === id
 
   return (
     <S.UserActionLayout>
@@ -14,19 +16,19 @@ const UserActions = () => {
         <UserActionButton
           text="회원 정보 수정"
           $width={11}
-          onClick={() => {}}
+          onClick={() => {
+            navigate(`/useredit/${id}`)
+          }}
         />
       ) : (
         <>
-          <UserActionButton
-            text="팔로우"
-            $width={9}
-            onClick={() => {}}
-          />
+          <UserFollowActionButton />
           <UserActionButton
             text="DM 보내기"
             $width={9}
-            onClick={() => {}}
+            onClick={() => {
+              navigate(`/directmessage/${id}`)
+            }}
           />
         </>
       )}

--- a/src/pages/Profile/components/UserProfile/components/UserActions/UserActions.tsx
+++ b/src/pages/Profile/components/UserProfile/components/UserActions/UserActions.tsx
@@ -3,6 +3,9 @@ import { useNavigate, useParams } from "react-router-dom"
 import useAuthUserStore from "@/stores/useAuthUserStore"
 import UserActionButton from "./UserActionButton"
 import UserFollowActionButton from "./UserFollowActionButton"
+import ConfirmModal from "@/components/Modal/components/ConfirmModal/ConfirmModal"
+import { NOT_LOGIN_MODAL_MESSAGE } from "@/constants/modalMessage"
+import useModal from "@/components/Modal/hooks/useModal"
 
 interface UserActionsProps {
   onFollowButtonClick: () => void
@@ -14,9 +17,30 @@ const UserActions = ({
   onUnFollowButtonClick,
 }: UserActionsProps) => {
   const navigate = useNavigate()
+  const { isShowModal, showModal, closeModal } = useModal()
+
   const { id } = useParams()
-  const { myId } = useAuthUserStore()
+  const { myId, isLoggedIn } = useAuthUserStore()
   const isMyPage = myId === id
+
+  const handleClickButton = (isDMPage?: boolean) => {
+    if (!isLoggedIn) {
+      showModal()
+      return
+    }
+    console.log(isDMPage)
+
+    if (isDMPage) {
+      navigate(`/directmessage/${id}`)
+    }
+  }
+
+  const handleAlertCloseButton = (isAccepted: boolean) => {
+    closeModal()
+    if (isAccepted) {
+      navigate("/login")
+    }
+  }
 
   return (
     <S.UserActionLayout>
@@ -33,13 +57,18 @@ const UserActions = ({
           <UserFollowActionButton
             onFollowButtonClick={onFollowButtonClick}
             onUnFollowButtonClick={onUnFollowButtonClick}
+            onClick={handleClickButton}
           />
           <UserActionButton
             text="DM 보내기"
             $width={9}
-            onClick={() => {
-              navigate(`/directmessage/${id}`)
-            }}
+            onClick={() => handleClickButton(true)}
+          />
+          <ConfirmModal
+            isShow={isShowModal}
+            onClose={handleAlertCloseButton}
+            message={NOT_LOGIN_MODAL_MESSAGE}
+            acceptButtonText={"확인"}
           />
         </>
       )}

--- a/src/pages/Profile/components/UserProfile/components/UserActions/UserActions.tsx
+++ b/src/pages/Profile/components/UserProfile/components/UserActions/UserActions.tsx
@@ -4,7 +4,15 @@ import useAuthUserStore from "@/stores/useAuthUserStore"
 import UserActionButton from "./UserActionButton"
 import UserFollowActionButton from "./UserFollowActionButton"
 
-const UserActions = () => {
+interface UserActionsProps {
+  onFollowButtonClick: () => void
+  onUnFollowButtonClick: () => void
+}
+
+const UserActions = ({
+  onFollowButtonClick,
+  onUnFollowButtonClick,
+}: UserActionsProps) => {
   const navigate = useNavigate()
   const { id } = useParams()
   const { myId } = useAuthUserStore()
@@ -22,7 +30,10 @@ const UserActions = () => {
         />
       ) : (
         <>
-          <UserFollowActionButton />
+          <UserFollowActionButton
+            onFollowButtonClick={onFollowButtonClick}
+            onUnFollowButtonClick={onUnFollowButtonClick}
+          />
           <UserActionButton
             text="DM 보내기"
             $width={9}

--- a/src/pages/Profile/components/UserProfile/components/UserActions/UserFollowActionButton.tsx
+++ b/src/pages/Profile/components/UserProfile/components/UserActions/UserFollowActionButton.tsx
@@ -12,17 +12,19 @@ interface followInfoProp {
 interface FollowButtonProps {
   onFollowButtonClick: () => void
   onUnFollowButtonClick: () => void
+  onClick: () => void
 }
 
 const UserFollowActionButton = ({
   onFollowButtonClick,
   onUnFollowButtonClick,
+  onClick,
 }: FollowButtonProps) => {
   const { id } = useParams()
-  const { user } = useAuthUserStore()
+  const { user, isLoggedIn } = useAuthUserStore()
 
-  const { fetchFollowMutate } = useFetchFollow()
-  const { fetchUnFollowMutate } = useFetchUnFollow()
+  const { fetchFollowMutate, FollowErrorAlertModal } = useFetchFollow()
+  const { fetchUnFollowMutate, UnFollowErrorAlertModal } = useFetchUnFollow()
 
   const followInfo = user.following.find(
     ({ user }: followInfoProp) => user === id,
@@ -30,6 +32,11 @@ const UserFollowActionButton = ({
   const followInfoId = followInfo?._id
 
   const handleFollowButton = () => {
+    if (!isLoggedIn) {
+      onClick()
+      return
+    }
+
     if (fetchFollowMutate.isPending || fetchUnFollowMutate.isPending) {
       return
     }
@@ -52,13 +59,21 @@ const UserFollowActionButton = ({
   }
 
   return (
-    <S.UserActionButton
-      $width={9}
-      onClick={handleFollowButton}
-      $isFollowing={!!followInfoId}
-    >
-      {followInfoId ? "언팔로우" : "팔로우"}
-    </S.UserActionButton>
+    <>
+      <S.UserActionButton
+        $width={9}
+        onClick={handleFollowButton}
+        $isFollowing={!!followInfoId}
+      >
+        {followInfoId ? "언팔로우" : "팔로우"}
+      </S.UserActionButton>
+      {isLoggedIn && (
+        <>
+          {FollowErrorAlertModal}
+          {UnFollowErrorAlertModal}
+        </>
+      )}
+    </>
   )
 }
 

--- a/src/pages/Profile/components/UserProfile/components/UserActions/UserFollowActionButton.tsx
+++ b/src/pages/Profile/components/UserProfile/components/UserActions/UserFollowActionButton.tsx
@@ -2,7 +2,6 @@ import * as S from "./UserActions.Styles"
 
 import useFetchFollow from "@/hooks/useFetchFollow"
 import useFetchUnFollow from "@/hooks/useFetchUnFollow"
-import { useEffect, useState } from "react"
 import { useParams } from "react-router-dom"
 import useAuthUserStore from "@/stores/useAuthUserStore"
 
@@ -25,16 +24,10 @@ const UserFollowActionButton = ({
   const { fetchFollowMutate } = useFetchFollow()
   const { fetchUnFollowMutate } = useFetchUnFollow()
 
-  const [followInfoId, setFollowInfoId] = useState("")
-
-  useEffect(() => {
-    const { following } = user
-
-    const followInfo = following.find(({ user }: followInfoProp) => user === id)
-    if (followInfo) {
-      setFollowInfoId(followInfo._id)
-    }
-  }, [])
+  const followInfo = user.following.find(
+    ({ user }: followInfoProp) => user === id,
+  )
+  const followInfoId = followInfo?._id
 
   const handleFollowButton = () => {
     if (fetchFollowMutate.isPending || fetchUnFollowMutate.isPending) {
@@ -44,7 +37,6 @@ const UserFollowActionButton = ({
     if (followInfoId) {
       fetchUnFollowMutate.mutate(followInfoId, {
         onSuccess: () => {
-          setFollowInfoId("")
           onUnFollowButtonClick()
         },
       })
@@ -53,8 +45,7 @@ const UserFollowActionButton = ({
     }
 
     fetchFollowMutate.mutate(id!, {
-      onSuccess: ({ _id }) => {
-        setFollowInfoId(_id)
+      onSuccess: () => {
         onFollowButtonClick()
       },
     })

--- a/src/pages/Profile/components/UserProfile/components/UserActions/UserFollowActionButton.tsx
+++ b/src/pages/Profile/components/UserProfile/components/UserActions/UserFollowActionButton.tsx
@@ -1,0 +1,69 @@
+import * as S from "./UserActions.Styles"
+
+import useFetchFollow from "@/hooks/useFetchFollow"
+import useFetchUnFollow from "@/hooks/useFetchUnFollow"
+import { useEffect, useState } from "react"
+import { API } from "@/apis/Api"
+import { useParams } from "react-router-dom"
+import useAuthUserStore from "@/stores/useAuthUserStore"
+
+interface followInfoProp {
+  user: string
+}
+
+const UserFollowActionButton = () => {
+  const { id } = useParams()
+  const { myId } = useAuthUserStore()
+  const { fetchFollowMutate } = useFetchFollow()
+  const { fetchUnFollowMutate } = useFetchUnFollow()
+
+  const [followInfoId, setFollowInfoId] = useState("")
+
+  useEffect(() => {
+    API.get(`/users/${myId}`)
+      .then((res) => res.data)
+      .then(({ following }) => {
+        const followInfo = following.find(
+          ({ user }: followInfoProp) => user === id,
+        )
+
+        if (followInfo) {
+          setFollowInfoId(followInfo._id)
+        }
+      })
+  }, [id, myId])
+
+  const handleFollowButton = () => {
+    if (fetchFollowMutate.isPending || fetchUnFollowMutate.isPending) {
+      return
+    }
+
+    if (followInfoId) {
+      fetchUnFollowMutate.mutate(followInfoId, {
+        onSuccess: () => {
+          setFollowInfoId("")
+        },
+      })
+
+      return
+    }
+
+    fetchFollowMutate.mutate(id!, {
+      onSuccess: ({ _id }) => {
+        setFollowInfoId(_id)
+      },
+    })
+  }
+
+  return (
+    <S.UserActionButton
+      $width={9}
+      onClick={handleFollowButton}
+      $isFollowing={!!followInfoId}
+    >
+      {followInfoId ? "언팔로우" : "팔로우"}
+    </S.UserActionButton>
+  )
+}
+
+export default UserFollowActionButton

--- a/src/pages/Profile/components/UserProfile/components/UserActions/UserFollowActionButton.tsx
+++ b/src/pages/Profile/components/UserProfile/components/UserActions/UserFollowActionButton.tsx
@@ -11,7 +11,15 @@ interface followInfoProp {
   user: string
 }
 
-const UserFollowActionButton = () => {
+interface FollowButtonProps {
+  onFollowButtonClick: () => void
+  onUnFollowButtonClick: () => void
+}
+
+const UserFollowActionButton = ({
+  onFollowButtonClick,
+  onUnFollowButtonClick,
+}: FollowButtonProps) => {
   const { id } = useParams()
   const { myId } = useAuthUserStore()
   const { fetchFollowMutate } = useFetchFollow()
@@ -42,6 +50,7 @@ const UserFollowActionButton = () => {
       fetchUnFollowMutate.mutate(followInfoId, {
         onSuccess: () => {
           setFollowInfoId("")
+          onUnFollowButtonClick()
         },
       })
 
@@ -51,6 +60,7 @@ const UserFollowActionButton = () => {
     fetchFollowMutate.mutate(id!, {
       onSuccess: ({ _id }) => {
         setFollowInfoId(_id)
+        onFollowButtonClick()
       },
     })
   }

--- a/src/pages/Profile/components/UserProfile/components/UserActions/UserFollowActionButton.tsx
+++ b/src/pages/Profile/components/UserProfile/components/UserActions/UserFollowActionButton.tsx
@@ -3,7 +3,6 @@ import * as S from "./UserActions.Styles"
 import useFetchFollow from "@/hooks/useFetchFollow"
 import useFetchUnFollow from "@/hooks/useFetchUnFollow"
 import { useEffect, useState } from "react"
-import { API } from "@/apis/Api"
 import { useParams } from "react-router-dom"
 import useAuthUserStore from "@/stores/useAuthUserStore"
 
@@ -21,25 +20,21 @@ const UserFollowActionButton = ({
   onUnFollowButtonClick,
 }: FollowButtonProps) => {
   const { id } = useParams()
-  const { myId } = useAuthUserStore()
+  const { user } = useAuthUserStore()
+
   const { fetchFollowMutate } = useFetchFollow()
   const { fetchUnFollowMutate } = useFetchUnFollow()
 
   const [followInfoId, setFollowInfoId] = useState("")
 
   useEffect(() => {
-    API.get(`/users/${myId}`)
-      .then((res) => res.data)
-      .then(({ following }) => {
-        const followInfo = following.find(
-          ({ user }: followInfoProp) => user === id,
-        )
+    const { following } = user
 
-        if (followInfo) {
-          setFollowInfoId(followInfo._id)
-        }
-      })
-  }, [id, myId])
+    const followInfo = following.find(({ user }: followInfoProp) => user === id)
+    if (followInfo) {
+      setFollowInfoId(followInfo._id)
+    }
+  }, [])
 
   const handleFollowButton = () => {
     if (fetchFollowMutate.isPending || fetchUnFollowMutate.isPending) {

--- a/src/pages/Profile/components/UserProfile/components/UserActions/UserFollowActionButton.tsx
+++ b/src/pages/Profile/components/UserProfile/components/UserActions/UserFollowActionButton.tsx
@@ -10,16 +10,10 @@ interface followInfoProp {
 }
 
 interface FollowButtonProps {
-  onFollowButtonClick: () => void
-  onUnFollowButtonClick: () => void
   onClick: () => void
 }
 
-const UserFollowActionButton = ({
-  onFollowButtonClick,
-  onUnFollowButtonClick,
-  onClick,
-}: FollowButtonProps) => {
+const UserFollowActionButton = ({ onClick }: FollowButtonProps) => {
   const { id } = useParams()
   const { user, isLoggedIn } = useAuthUserStore()
 
@@ -42,20 +36,12 @@ const UserFollowActionButton = ({
     }
 
     if (followInfoId) {
-      fetchUnFollowMutate.mutate(followInfoId, {
-        onSuccess: () => {
-          onUnFollowButtonClick()
-        },
-      })
+      fetchUnFollowMutate.mutate(followInfoId)
 
       return
     }
 
-    fetchFollowMutate.mutate(id!, {
-      onSuccess: () => {
-        onFollowButtonClick()
-      },
-    })
+    fetchFollowMutate.mutate(id!)
   }
 
   return (

--- a/src/pages/Profile/components/UserProfile/components/UserFollowInfo/UserFollowInfo.tsx
+++ b/src/pages/Profile/components/UserProfile/components/UserFollowInfo/UserFollowInfo.tsx
@@ -1,10 +1,10 @@
+import { getConvertedCount } from "@/util/getConvertedCount"
 import * as S from "./UserFollowInfo.Styles"
 import CircleIcon from "@mui/icons-material/Circle"
-import { convertFollowCount } from "@/util/convertFollowCount"
 
 const UserFollowInfo = () => {
-  const following = convertFollowCount(44343324)
-  const follower = convertFollowCount(321)
+  const following = getConvertedCount(15000)
+  const follower = getConvertedCount(321)
 
   return (
     <S.UserFollowInfoLayout>

--- a/src/pages/Profile/components/UserProfile/components/UserFollowInfo/UserFollowInfo.tsx
+++ b/src/pages/Profile/components/UserProfile/components/UserFollowInfo/UserFollowInfo.tsx
@@ -3,18 +3,14 @@ import * as S from "./UserFollowInfo.Styles"
 import CircleIcon from "@mui/icons-material/Circle"
 
 interface UserFollowInfoProps {
-  followingCount?: number
-  followerCount?: number
+  followingCount: number
+  followerCount: number
 }
 
 const UserFollowInfo = ({
   followingCount,
   followerCount,
 }: UserFollowInfoProps) => {
-  if (followingCount === undefined || followerCount === undefined) {
-    return
-  }
-
   const following = getConvertedCount(followingCount)
   const follower = getConvertedCount(followerCount)
 

--- a/src/pages/Profile/components/UserProfile/components/UserFollowInfo/UserFollowInfo.tsx
+++ b/src/pages/Profile/components/UserProfile/components/UserFollowInfo/UserFollowInfo.tsx
@@ -2,9 +2,21 @@ import { getConvertedCount } from "@/util/getConvertedCount"
 import * as S from "./UserFollowInfo.Styles"
 import CircleIcon from "@mui/icons-material/Circle"
 
-const UserFollowInfo = () => {
-  const following = getConvertedCount(15000)
-  const follower = getConvertedCount(321)
+interface UserFollowInfoProps {
+  followingCount?: number
+  followerCount?: number
+}
+
+const UserFollowInfo = ({
+  followingCount,
+  followerCount,
+}: UserFollowInfoProps) => {
+  if (followingCount === undefined || followerCount === undefined) {
+    return
+  }
+
+  const following = getConvertedCount(followingCount)
+  const follower = getConvertedCount(followerCount)
 
   return (
     <S.UserFollowInfoLayout>

--- a/src/pages/Profile/components/UserProfile/components/UserNickname.tsx
+++ b/src/pages/Profile/components/UserProfile/components/UserNickname.tsx
@@ -1,7 +1,11 @@
 import * as S from "../UserProfile.Styles"
 
-const UserNickname = () => {
-  return <S.UserNickNameContainer>UserNickname</S.UserNickNameContainer>
+interface UserNicknameProps {
+  nickName?: string
+}
+
+const UserNickname = ({ nickName }: UserNicknameProps) => {
+  return <S.UserNickNameContainer>{nickName}</S.UserNickNameContainer>
 }
 
 export default UserNickname

--- a/src/pages/Profile/components/UserProfile/components/UserProfileImage.tsx
+++ b/src/pages/Profile/components/UserProfile/components/UserProfileImage.tsx
@@ -1,7 +1,22 @@
 import * as S from "../UserProfile.Styles"
+import { useEffect, useState } from "react"
 
-const UserProfileImage = () => {
-  return <S.UserProfileImageContainer></S.UserProfileImageContainer>
+interface UserProfileImageProp {
+  image?: string
+}
+
+const UserProfileImage = ({ image }: UserProfileImageProp) => {
+  const [profileImage, setProfileImage] = useState<string | undefined>("")
+
+  useEffect(() => {
+    setProfileImage(image)
+  }, [image])
+
+  return (
+    <S.UserProfileImageContainer
+      src={profileImage}
+    ></S.UserProfileImageContainer>
+  )
 }
 
 export default UserProfileImage

--- a/src/pages/Profile/components/UserProfile/components/UserProfileImage.tsx
+++ b/src/pages/Profile/components/UserProfile/components/UserProfileImage.tsx
@@ -1,16 +1,12 @@
 import * as S from "../UserProfile.Styles"
-import { useEffect, useState } from "react"
+import defaultImage from "@/assets/standard.jpeg"
 
 interface UserProfileImageProp {
   image?: string
 }
 
 const UserProfileImage = ({ image }: UserProfileImageProp) => {
-  const [profileImage, setProfileImage] = useState<string | undefined>("")
-
-  useEffect(() => {
-    setProfileImage(image)
-  }, [image])
+  const profileImage = image ? image : defaultImage
 
   return (
     <S.UserProfileImageContainer

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -30,7 +30,7 @@ const YAPRoute = () => {
           element={<UserEdit />}
         />
         <Route
-          path="/profile/:id?"
+          path="/profile/:id"
           element={<Profile />}
         />
         {/* query string Category 구별 */}

--- a/src/util/getConvertedCount.ts
+++ b/src/util/getConvertedCount.ts
@@ -1,8 +1,8 @@
-// following, follower 수에 단위를 붙여주는 함수(0~9999만)
-export const convertFollowCount = (count: number): string => {
+// 수를 천 단위까지 끊고 단위를 붙여주는 함수(0~9999만)
+export const getConvertedCount = (count: number): string => {
   if (count >= 10000) {
     const integer = count.toString().slice(0, -4) //정수(만 단위)
-    const decimal = count.toString().slice(-1) //소수(천 단위)
+    const decimal = count.toString().slice(integer.length, integer.length + 1) //소수(천 단위)
 
     if (decimal === "0") {
       return `${integer}만`


### PR DESCRIPTION
## #️⃣연관된 이슈
close #95 
<!-- #이슈번호, #이슈번호-->

## 💡 핵심적으로 구현된 사항
- 유저 페이지의 상단 부분(프로필 영역)에 api 데이터를 적용시켰습니다
- useParams로 유저 id를 얻은 후에 api 호출로 데이터를 가져와 컴포넌트에 주입했습니다
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 "스크린샷"과 함께 적어 주세요 -->

https://github.com/prgrms-fe-devcourse/FEDC5_Yap_YUNHO/assets/68155263/d74876c9-2cb9-4465-afb0-c5390d95cee0


## ➕ 그 외에 추가적으로 구현된 사항
- following 수를 변환해주는 util 함수의 네이밍 변경(`convertFollowCount`->`getConvertedCount`)
- count의 천 단위를 제대로 가져오도록 버그 수정
<!-- 없으면 "없음" 이라고 기재해 주세요 -->
<!-- 주 Task 이외의 작업한 변경 사항  -->

## 🤔 테스트,검증 && 고민 사항

<!-- 배포에서 체크해봐야 할 부분 -->
<!-- 궁금한 점, 팀원들의 의견이 필요한 부분, 크로스체크가 필요한 부분 등 -->

### 📌 PR Comment 작성 시 Prefix for Reviewers

<!-- * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
* P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
* P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore) -->
